### PR TITLE
adds security group for memcached

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -56,7 +56,7 @@ jobs:
       - OUT: aws_vpc_tf_state
     on_success:
       script:
-        - shipctl put_resource_state_multi aws_vpc_tf_info "versionName=$vpc_name" "vpc_id=$(terraform output vpc_id)" "vpc_region=$vpc_region" "vpc_public_sg_id=$(terraform output vpc_public_sg_id)" "vpc_public_sn_id=$(terraform output vpc_public_sn_id)"
+        - shipctl put_resource_state_multi aws_vpc_tf_info "versionName=$vpc_name" "vpc_id=$(terraform output vpc_id)" "vpc_region=$vpc_region" "vpc_public_sg_id=$(terraform output vpc_public_sg_id)" "vpc_public_sn_id=$(terraform output vpc_public_sn_id)" "vpc_memcached_sg_id=$(terraform output vpc_memcached_sg_id)"
     always:
       script:
         - shipctl copy_file_to_resource_state terraform.tfstate aws_vpc_tf_state

--- a/shippable.yml
+++ b/shippable.yml
@@ -56,7 +56,7 @@ jobs:
       - OUT: aws_vpc_tf_state
     on_success:
       script:
-        - shipctl put_resource_state_multi aws_vpc_tf_info "versionName=$vpc_name" "vpc_id=$(terraform output vpc_id)" "vpc_region=$vpc_region" "vpc_public_sg_id=$(terraform output vpc_public_sg_id)" "vpc_public_sn_id=$(terraform output vpc_public_sn_id)" "vpc_memcached_sg_id=$(terraform output vpc_memcached_sg_id)"
+        - shipctl put_resource_state_multi aws_vpc_tf_info "versionName=$vpc_name" "vpc_id=$(terraform output vpc_id)" "vpc_region=$vpc_region" "vpc_public_sg_id=$(terraform output vpc_public_sg_id)" "vpc_public_sn_id=$(terraform output vpc_public_sn_id)" "vpc_private_sg_id=$(terraform output vpc_private_sg_id)"
     always:
       script:
         - shipctl copy_file_to_resource_state terraform.tfstate aws_vpc_tf_state

--- a/vpc.tf
+++ b/vpc.tf
@@ -84,11 +84,12 @@ resource "aws_security_group" "vpc_public_sg" {
   }
 }
 
-resource "aws_security_group" "vpc_memcached_sg" {
-  name = "demo_memcached_sg"
-  description = "demo access to Amazon Elasticache - Memcached security group"
+resource "aws_security_group" "vpc_private_sg" {
+  name = "demo_private_sg"
+  description = "demo security group to access private ports"
   vpc_id = "${aws_vpc.vpc_name.id}"
 
+  # allow memcached port within VPC
   ingress {
     from_port = 11211
     to_port = 11211
@@ -98,7 +99,6 @@ resource "aws_security_group" "vpc_memcached_sg" {
   }
 
   egress {
-    # allow all traffic to private SN
     from_port = "0"
     to_port = "0"
     protocol = "-1"
@@ -106,7 +106,7 @@ resource "aws_security_group" "vpc_memcached_sg" {
       "0.0.0.0/0"]
   }
   tags {
-    Name = "demo_memcached_sg"
+    Name = "demo_private_sg"
   }
 }
 
@@ -126,6 +126,6 @@ output "vpc_public_sg_id" {
   value = "${aws_security_group.vpc_public_sg.id}"
 }
 
-output "vpc_memcached_sg_id" {
-  value = "${aws_security_group.vpc_memcached_sg.id}"
+output "vpc_private_sg_id" {
+  value = "${aws_security_group.vpc_private_sg.id}"
 }

--- a/vpc.tf
+++ b/vpc.tf
@@ -84,6 +84,32 @@ resource "aws_security_group" "vpc_public_sg" {
   }
 }
 
+resource "aws_security_group" "vpc_memcached_sg" {
+  name = "demo_memcached_sg"
+  description = "demo access to Amazon Elasticache - Memcached security group"
+  vpc_id = "${aws_vpc.vpc_name.id}"
+
+  ingress {
+    from_port = 11211
+    to_port = 11211
+    protocol = "tcp"
+    cidr_blocks = [
+      "${var.vpc_public_subnet_1_cidr}"]
+  }
+
+  egress {
+    # allow all traffic to private SN
+    from_port = "0"
+    to_port = "0"
+    protocol = "-1"
+    cidr_blocks = [
+      "0.0.0.0/0"]
+  }
+  tags {
+    Name = "demo_memcached_sg"
+  }
+}
+
 output "vpc_region" {
   value = "${var.vpc_region}"
 }
@@ -98,4 +124,8 @@ output "vpc_public_sn_id" {
 
 output "vpc_public_sg_id" {
   value = "${aws_security_group.vpc_public_sg.id}"
+}
+
+output "vpc_memcached_sg_id" {
+  value = "${aws_security_group.vpc_memcached_sg.id}"
 }


### PR DESCRIPTION
https://github.com/devops-recipes/prov_aws_vpc_terraform/issues/2

This security group will allow accessing the Amazon ElastiCache Memcached cluster from ec2 instances inside the same VPC.

Reference:
- https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/elasticache-vpc-accessing.html#elasticache-vpc-accessing-same-vpc
- https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/VPCs.EC.html ( Refer [diagram](https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/images/vpc-overview-diagram.png) for overview )
